### PR TITLE
Sort out GoCD agent with new base AMI and new naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/*
 berks-cookbooks/
 
 build.log
+ami-id

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 
+cookbook 'docker', '~> 2.13.0'
 cookbook 'gocd', '~> 1.1.1'
 cookbook 'chef-dk', '~> 3.1.0'
 cookbook 'git', '~> 4.4.1'

--- a/Rakefile
+++ b/Rakefile
@@ -22,9 +22,9 @@ task :packer, :source_ami_id do |_, args|
   sh 'rm -rf berks-cookbooks/*'
   sh 'berks vendor'
   sh 'packer validate template.json'
-  
+
   # Execute Packer to store AMI ID in a file called 'ami-id'
-  sh "packer build -machine-readable -var source_ami=#{args.source_ami_id} template.json | tee build.log"
+  sh "packer build -machine-readable -var 'source_ami=#{args.source_ami_id}' template.json | tee build.log"
   @ami_id=`grep 'artifact,0,id' build.log | cut -d, -f6 | cut -d: -f2`.chomp
   File.write('ami-id', @ami_id)
 end

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export AWS_REGION=us-east-1
+export AWS_REGION=eu-west-1
 
 ## Execute the CI task from the Rakefile
 #sudo $(which chef) exec rake ci

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ export AWS_REGION=eu-west-1
 
 ## Obtain the source AMI to use for our Packer build.
 base_ami_id=$(aws ec2 describe-images \
-    --filters Name=tag-key,Values=name Name=tag-value,Values=linux-ubuntu-base \
+    --filters Name=tag-key,Values=Name Name=tag-value,Values=base-ubuntu-16.04 \
     --output text \
     --query 'Images[*].[ImageId,CreationDate]' \
     --region $AWS_REGION \

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 
 ## Obtain the source AMI to use for our Packer build.
 base_ami_id=$(aws ec2 describe-images \
---filters Name=tag-key,Values=name Name=tag-value,Values=linux-docker-base \
+--filters Name=tag-key,Values=name Name=tag-value,Values=linux-ubuntu-base \
 --output text \
 --query 'Images[0].ImageId' \
 )

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AWS_REGION=us-east-1
+export AWS_REGION=us-east-1
 
 ## Execute the CI task from the Rakefile
 #sudo $(which chef) exec rake ci

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
+AWS_REGION=us-east-1
+
 ## Execute the CI task from the Rakefile
 #sudo $(which chef) exec rake ci
 
 ## Obtain the source AMI to use for our Packer build.
 base_ami_id=$(aws ec2 describe-images \
---filters Name=tag-key,Values=name Name=tag-value,Values=linux-ubuntu-base \
---output text \
---query 'Images[0].ImageId' \
+    --filters Name=tag-key,Values=name Name=tag-value,Values=linux-ubuntu-base \
+    --output text \
+    --query 'Images[*].[ImageId,CreationDate]' \
+    --region $AWS_REGION \
+    | sort -n -k 2 -r | cut -f1 | head -n1 \
 )
 
 ## Build an AMI for this cookbook

--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
     "version":           "{{env `VERSION`}}",
     "aws_access_key":    "{{env `AWS_ACCESS_KEY`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_KEY`}}",
-    "name":              "gocd-linux-agent",
+    "name":              "gocd_agent-ubuntu-16.04",
     "region":            "{{env `AWS_REGION`}}",
     "source_ami":        "ami-9abea4fb",
     "instance_type":     "t2.medium",
@@ -20,10 +20,10 @@
       "ssh_username":    "ubuntu",
       "ssh_private_ip":  "false",
       "user_data_file":  "{{user `user_data_file`}}",
-      "ami_name":        "{{user `name`}} {{timestamp}}",
+      "ami_name":        "{{user `name`}}-{{timestamp}}",
       "ami_description": "{{user `name`}} AMI",
       "run_tags": { "ami-create": "{{user `name`}}" },
-      "tags": { "name": "{{user `name`}}", "created": "{{timestamp}}" },
+      "tags": { "Name": "{{user `name`}}", "Created": "{{timestamp}}" },
       "associate_public_ip_address": true
     }
   ],

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     "aws_access_key":    "{{env `AWS_ACCESS_KEY`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_KEY`}}",
     "name":              "gocd-linux-agent",
-    "region":            "eu-west-1",
+    "region":            "{{env `AWS_REGION`}}",
     "source_ami":        "ami-9abea4fb",
     "instance_type":     "t2.micro",
     "ssh_username":      "ubuntu"

--- a/template.json
+++ b/template.json
@@ -6,7 +6,7 @@
     "name":              "gocd-linux-agent",
     "region":            "{{env `AWS_REGION`}}",
     "source_ami":        "ami-9abea4fb",
-    "instance_type":     "t2.micro",
+    "instance_type":     "t2.medium",
     "ssh_username":      "ubuntu"
   },
   "builders": [
@@ -15,8 +15,6 @@
       "access_key":      "{{user `aws_access_key`}}",
       "secret_key":      "{{user `aws_secret_key`}}",
       "region":          "{{user `region`}}",
-      "vpc_id":          "{{user `vpc_id`}}",
-      "subnet_id":       "{{user `subnet_id`}}",
       "source_ami":      "{{user `source_ami`}}",
       "instance_type":   "{{user `instance_type`}}",
       "ssh_username":    "ubuntu",


### PR DESCRIPTION
This includes two pieces of work:

1. It uses the new, working linux-ubuntu-base image rather than linux-docker-base which had gone missing.
2. It applies the new naming convention and tags the name correctly ("Name" rather than "name").