### PR TITLE
Bring the build up to date with correct base AMI and Go.CD version.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'docker', '~> 2.13.0'
-cookbook 'gocd', '~> 1.1.1'
+cookbook 'gocd', '~> 1.3.2'
 cookbook 'chef-dk', '~> 3.1.0'
 cookbook 'git', '~> 4.4.1'
 cookbook 'sbp_packer', '~> 1.4.1'

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ base_ami_id=$(aws ec2 describe-images \
     --output text \
     --query 'Images[*].[ImageId,CreationDate]' \
     --region $AWS_REGION \
-    | sort -n -k 2 -r | cut -f1 | head -n1 \
+    | sort -k 2 -r | cut -f1 | head -n1 \
 )
 
 ## Build an AMI for this cookbook

--- a/build.sh
+++ b/build.sh
@@ -16,3 +16,11 @@ base_ami_id=$(aws ec2 describe-images \
 
 ## Build an AMI for this cookbook
 $(which chef) exec rake packer[$base_ami_id]
+
+declare -a GRANTS=(378030785168 638960451485 165162103257 337667769842 430811725848 210277190260)
+AMI_ID=$(cat ami-id)
+
+for g in ${GRANTS[@]}; do
+    echo Granting launch permission for $AMI_ID to $g
+    aws ec2 modify-image-attribute --image-id $AMI_ID --launch-permission "{\"Add\": [{\"UserId\":\"$g\"}]}"
+done

--- a/recipes/configure_docker.rb
+++ b/recipes/configure_docker.rb
@@ -5,6 +5,12 @@
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
 # Install Docker
+
+docker_service 'default' do
+  action [:create, :start]
+end
+
+
 cookbook_file "/tmp/configure_docker.sh" do
   source "configure_docker.sh"
   mode 0755

--- a/recipes/install_agent.rb
+++ b/recipes/install_agent.rb
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
-node.override['gocd']['agent']['go_server_host'] = node['gocd-agent-linux']['server-host-name']
+node.override['gocd']['agent']['go_server_url'] = 'https://' + node['gocd-agent-linux']['server-host-name'] + ':8154/go'
 node.override['gocd']['agent']['package_file']['url'] = 'https://download.go.cd/binaries/16.2.1-3027/deb/go-agent-16.2.1-3027.deb'
 
 include_recipe 'gocd::agent'


### PR DESCRIPTION
When selecting the base AMI, the AMIs returned from the query should be sorted by date and the most recent taken. Specifying the -n flag gives the wrong results in some cases.

This pull request also brings the Go.CD cookbook version up to date, since there have been some breaking changes that were stopping it from building properly.